### PR TITLE
Fix whitespace, nose invocation and depends

### DIFF
--- a/security/py-pymacaroons-pynacl/Makefile
+++ b/security/py-pymacaroons-pynacl/Makefile
@@ -14,9 +14,9 @@ LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}pynacl>=0.3.0:${PORTSDIR}/security/py-pynacl \
-			${PYTHON_PKGNAMEPREFIX}six>=1.8.0:${PORTSDIR}/devel/py-six
-TEST_DEPENDS=	nosetests:${PORTSDIR}/devel/py-nose \
-			${PYTHON_PKGNAMEPREFIX}hypothesis>0:${PORTSDIR}/devel/py-hypothesis
+		${PYTHON_PKGNAMEPREFIX}six>=1.8.0:${PORTSDIR}/devel/py-six
+TEST_DEPENDS=	${PYTHON_PKGNAMEPREFIX}nose>0:${PORTSDIR}/devel/py-nose \
+		${PYTHON_PKGNAMEPREFIX}hypothesis>0:${PORTSDIR}/devel/py-hypothesis
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	matrix-org
@@ -26,6 +26,6 @@ USES=		python
 USE_PYTHON=	autoplist distutils
 
 do-test:
-	@(cd ${WRKSRC} && nosetests)
+	@(cd ${WRKSRC} && nosetests-${PYTHON_VER})
 
 .include <bsd.port.mk>


### PR DESCRIPTION
- Fix tab alignment
- Must invoke version specific nosetests script (add `PYTHON_VER` suffix). 

Probably better to use, in order of preference:
- `${PYTHON_CMD} ${PYDISTUTILS_SETUP} nosetests` (setuptools command)
- `${PYTHON_CMD} -m nosetests`
